### PR TITLE
feat: add age value in user data response

### DIFF
--- a/routes/mixutils.js
+++ b/routes/mixutils.js
@@ -121,6 +121,7 @@ const getUserInfo = async usersId => {
               {
                 name: result.name,
                 surname: result.surname,
+                age: result.age,
                 photo: result.photo,
                 city: result.city,
                 town: result.town,


### PR DESCRIPTION
Add `age` in user response for wholikes/ilikes/matches list.


Closes: [ISSUE n. 164 ](https://github.com/ilPhil/roomatch/issues/164)